### PR TITLE
Support changing the affinity of indexed columns

### DIFF
--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
@@ -128,11 +128,11 @@ class Migration(
                 renameTable(tableMerge.name, table2.name)
             }
 
-            tableDiff.indicesDiff.added.forEach {
-                createTableIndex(table2, it)
-            }
             tableDiff.indicesDiff.removed.forEach {
                 dropTableIndex(it)
+            }
+            tableDiff.indicesDiff.added.forEach {
+                createTableIndex(table2, it)
             }
         }
 

--- a/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/13.json
+++ b/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/13.json
@@ -1,0 +1,140 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "e57cb6d2e64f805d58a6002caa9890d6",
+    "entities": [
+      {
+        "tableName": "Object1Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `intValRenamed` INTEGER NOT NULL, `stringValRenamed` TEXT NOT NULL, `nullIntVal` INTEGER, `nullStringVal` TEXT NOT NULL, `stringValIndexed` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intValRenamed",
+            "columnName": "intValRenamed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValRenamed",
+            "columnName": "stringValRenamed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nullIntVal",
+            "columnName": "nullIntVal",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nullStringVal",
+            "columnName": "nullStringVal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValIndexed",
+            "columnName": "stringValIndexed",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Object1Dbo_stringValIndexed",
+            "unique": false,
+            "columnNames": [
+              "stringValIndexed"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Object1Dbo_stringValIndexed` ON `${TABLE_NAME}` (`stringValIndexed`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Object2Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Object3Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`prop1` TEXT NOT NULL, `prop2` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "prop1",
+            "columnName": "prop1",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prop2",
+            "columnName": "prop2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Object3Dbo_prop1_prop2",
+            "unique": false,
+            "columnNames": [
+              "prop1",
+              "prop2"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Object3Dbo_prop1_prop2` ON `${TABLE_NAME}` (`prop1`, `prop2`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [
+      {
+        "viewName": "ObjectDboView",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT item.id AS oneId, (SELECT id FROM Object2Dbo WHERE id = item.id) AS twoId  FROM Object1Dbo item"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e57cb6d2e64f805d58a6002caa9890d6')"
+    ]
+  }
+}

--- a/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/14.json
+++ b/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/14.json
@@ -1,0 +1,140 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "d2807bb8dbd0ecabc669a3ab75e67d10",
+    "entities": [
+      {
+        "tableName": "Object1Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `intValRenamed` INTEGER NOT NULL, `stringValRenamed` TEXT NOT NULL, `nullIntVal` INTEGER, `nullStringVal` TEXT NOT NULL, `stringValIndexed` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intValRenamed",
+            "columnName": "intValRenamed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValRenamed",
+            "columnName": "stringValRenamed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nullIntVal",
+            "columnName": "nullIntVal",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nullStringVal",
+            "columnName": "nullStringVal",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValIndexed",
+            "columnName": "stringValIndexed",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Object1Dbo_stringValIndexed",
+            "unique": false,
+            "columnNames": [
+              "stringValIndexed"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Object1Dbo_stringValIndexed` ON `${TABLE_NAME}` (`stringValIndexed`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Object2Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Object3Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`prop1` INTEGER NOT NULL, `prop2` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "prop1",
+            "columnName": "prop1",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prop2",
+            "columnName": "prop2",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Object3Dbo_prop1_prop2",
+            "unique": false,
+            "columnNames": [
+              "prop1",
+              "prop2"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Object3Dbo_prop1_prop2` ON `${TABLE_NAME}` (`prop1`, `prop2`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [
+      {
+        "viewName": "ObjectDboView",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT item.id AS oneId, (SELECT id FROM Object2Dbo WHERE id = item.id) AS twoId  FROM Object1Dbo item"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd2807bb8dbd0ecabc669a3ab75e67d10')"
+    ]
+  }
+}

--- a/RoomigrantTest/src/androidTest/java/dev/matrix/roomigrant/test/DatabaseTest.kt
+++ b/RoomigrantTest/src/androidTest/java/dev/matrix/roomigrant/test/DatabaseTest.kt
@@ -21,7 +21,7 @@ class DatabaseTest {
 		val db = migrationHelper.createDatabase(name, 1).let {
 			migrationHelper.runMigrationsAndValidate(
 					name,
-					12,
+					14,
 					true,
 					*Database_Migrations.build()
 			)

--- a/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Database.kt
+++ b/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Database.kt
@@ -8,8 +8,8 @@ import dev.matrix.roomigrant.GenerateRoomMigrations
  * @author matrixdev
  */
 @Database(
-        version = 12,
-        entities = [Object1Dbo::class, Object2Dbo::class],
+        version = 14,
+        entities = [Object1Dbo::class, Object2Dbo::class, Object3Dbo::class],
         views = [ObjectDboView::class]
 )
 @GenerateRoomMigrations(Rules::class)
@@ -17,3 +17,4 @@ abstract class Database : RoomDatabase() {
     abstract val object1Dao: Object1Dao
     abstract val object2Dao: Object2Dao
 }
+

--- a/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Object3Dbo.kt
+++ b/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Object3Dbo.kt
@@ -1,0 +1,10 @@
+package dev.matrix.roomigrant.test
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(indices = [Index("prop1", "prop2")])
+data class Object3Dbo(val prop1: Int,
+                      val prop2: Int,
+                      @PrimaryKey(autoGenerate = false) val id: Int)


### PR DESCRIPTION
### Issue
* If the type/affinity of an indexed field changes between two schema versions, such as from `TEXT` to `INTEGER`, the index is no recreated in the migration.
* The "index" object in the json doesn't actually include affinity information anywhere.

### Fix
For each index, get each column name from the `columns` list.  
For each column name, find the actual field in the `fieldsMap` property of the `Field`.  
Create tuples for each field which represent the name, affinity, and nullability.
When comparing indices, compare their lists of these tuples instead of just the column names.