### PR TITLE
preserve indices when recreating a table

### DIFF
--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
@@ -124,15 +124,22 @@ class Migration(
                 sb.append(" FROM `").append(table1!!.name).append("`")
 
                 execSql(sb.toString())
+                tableDiff.indicesDiff.same.forEach {
+                    createTableIndex(table2, it)
+                }
+                tableDiff.indicesDiff.added.forEach {
+                    createTableIndex(table2, it)
+                }
                 dropTable(table1.name)
                 renameTable(tableMerge.name, table2.name)
-            }
+            } else {
 
-            tableDiff.indicesDiff.removed.forEach {
-                dropTableIndex(it)
-            }
-            tableDiff.indicesDiff.added.forEach {
-                createTableIndex(table2, it)
+                tableDiff.indicesDiff.removed.forEach {
+                    dropTableIndex(it)
+                }
+                tableDiff.indicesDiff.added.forEach {
+                    createTableIndex(table2, it)
+                }
             }
         }
 
@@ -148,7 +155,7 @@ class Migration(
             val old = viewDiff.old
             val new = viewDiff.new
 
-            old?.name?.let { dropView(it)}
+            old?.name?.let { dropView(it) }
             createView(new)
         }
 


### PR DESCRIPTION
### Issue
When dropping/recreating a table without changing the index columns, the index isn't re-added to the new table.

### Fix
Add all "changed" and "same" indices for any table when it's being recreated.