### PR TITLE
enable PRAGMA legacy_alter_table for table renames in API 30+ / SQLite 3.25.2+

### DIFF
--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
@@ -67,6 +67,12 @@ class Migration(
             createTableIndices(tableDiff.new)
         }
 
+        val pendingTableRename = diff.changedTables.any { it.fieldsDiff.wasChanged || it.nameChanged }
+
+        if (pendingTableRename) {
+            execSql("PRAGMA legacy_alter_table=ON;")
+        }
+
         for (tableDiff in diff.changedTables) {
             val table1 = tableDiff.old
             val table2 = tableDiff.new


### PR DESCRIPTION
### Issue
API 30 increases the SQLite version from 3.22.0 to 3.28.0.  This breaks migrations when renaming a table which is referenced by a `View`, because `ALTER_TABLE` now updates `View`s.  So this common code:
```
DROP TABLE Foo;
ALTER TABLE NewFoo RENAME TO Foo;
```
Attempts to reference a table named `Foo` immediately after it was deleted and immediately before `NewFoo` is renamed to `Foo`.

Alec Strong wrote a nice little article on it: https://www.alecstrong.com/2020/07/sqlite-sdk-30/

### Fix
We can't technically do an SDK version check since custom ROMs can use different SQLite versions as well.  So, the simplest solution seems to be adding `PRAGMA legacy_alter_table=ON` once at the beginning of any migration which includes a table rename.